### PR TITLE
updated version of minimist to 1.2.5 to correct the security warnings…

### DIFF
--- a/NapiBinding/package-lock.json
+++ b/NapiBinding/package-lock.json
@@ -432,8 +432,8 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -462,7 +462,7 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "1.2.5"
       }
     },
     "node-addon-api": {


### PR DESCRIPTION
Github raised some security problems around one of the many libraries the NAPI binding pulls in. 

I've updated the minimum revision of minims to 1.2.5 as per the security suggestion. 